### PR TITLE
feat: allow for lowercase platform specification in samples.tsv

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -89,7 +89,7 @@ def get_bwa_extra(wildcards):
     Set -q option for independent mapping qualities for split reads (Circle-Map uses this).
     """
     return r"-q -R '@RG\tID:{sample}\tSM:{sample}\tPL:{platform}'".format(
-        sample=wildcards.sample, platform=samples.loc[wildcards.sample, "platform"]
+        sample=wildcards.sample, platform=samples.loc[wildcards.sample, "platform"].upper()
     )
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -89,7 +89,8 @@ def get_bwa_extra(wildcards):
     Set -q option for independent mapping qualities for split reads (Circle-Map uses this).
     """
     return r"-q -R '@RG\tID:{sample}\tSM:{sample}\tPL:{platform}'".format(
-        sample=wildcards.sample, platform=samples.loc[wildcards.sample, "platform"].upper()
+        sample=wildcards.sample,
+        platform=samples.loc[wildcards.sample, "platform"].upper(),
     )
 
 


### PR DESCRIPTION
this should allow for easier compatibility with samples.tsv files for the cyrcular-calling workflow