### PR TITLE
fix: adjust schema to allow lowercase platform spec

### DIFF
--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -18,7 +18,10 @@ properties:
   platform:
     type: string
     enum:
+      - "illumina"
       - "ILLUMINA"
+      - "nanopore"
+      - "NANOPORE"
     description: used sequencing platform
 
 required:


### PR DESCRIPTION
also allow for platform `nanopore`, to allow loading as a module in a workflow that also processes nanopore samples (with a different module, but the same samples.tsv)