### PR TITLE
fix: increase bwa_mem memory requirement to 6 GB per thread

### DIFF
--- a/workflow/rules/mapping.smk
+++ b/workflow/rules/mapping.smk
@@ -13,7 +13,7 @@ rule bwa_mem:
         sort_extra="",  # Extra args for samtools/picard.
     threads: 8
     resources:
-        mem_mb=lambda wc, threads: threads * 4000,
+        mem_mb=lambda wc, threads: threads * 6000,
     wrapper:
         "v1.21.2/bio/bwa/mem"
 


### PR DESCRIPTION
This should then definitely be in line with the 5.5 GB per thread mentioned here: https://sourceforge.net/p/bio-bwa/mailman/message/32268544/