### PR TITLE
perf: make circle_map_realign more parallelized, try mem_mb dependent on thread number

### DIFF
--- a/workflow/rules/circle_map.smk
+++ b/workflow/rules/circle_map.smk
@@ -41,9 +41,9 @@ rule circle_map_realign:
         "logs/circle-map/{sample}.circles.log",
     conda:
         "../envs/circle_map.yaml"
-    threads: 4
+    threads: 16
     resources:
-        mem_mb=lambda wc, input: input.size_mb * 2.5,
+        mem_mb=lambda wc, threads: threads * 5000,
     shell:
         "Circle-Map Realign "
         " -i {input.candidates_bam} "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated resource allocation and threading configuration for improved performance during realignment steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->